### PR TITLE
Change "C# 3.5" to ".NET 3.5"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This file describes the latest pushed changes. For documentation of earlier rele
 
 
 # Requirements
-Requires C# 3.5 or newer
+Requires .NET 3.5 or newer
 
 
 # Resharper approved


### PR DESCRIPTION
There's no such thing as C# 3.5. C# 3.0 was the version of C# introduced with .NET 3.5, but I think you actually meant .NET 3.5 here.

https://www.reddit.com/r/csharp/comments/31b8x7/automate_unit_test_assert_writing/cq02u2a