### PR TITLE
Add map projection

### DIFF
--- a/StatePrinter.Tests/FieldHarvesters/ProjectionHarvesterTest.cs
+++ b/StatePrinter.Tests/FieldHarvesters/ProjectionHarvesterTest.cs
@@ -83,6 +83,17 @@ namespace StatePrinter.Tests.FieldHarvesters
         }
 
         [Test]
+        public void TestFluintInterface_map()
+        {
+            var cfg = TestHelper.CreateTestConfiguration();
+            cfg.Project.Map<A>(x => new {dims="hejsa", ups=x.Name});
+            var printer = new Stateprinter(cfg);
+
+            var state = printer.PrintObject(new A { X = DateTime.Now, Name = "Charly" });
+            Assert.AreEqual(@"new A() { dims = ""hejsa"" ups = ""Charly"" }", state);
+        }
+
+        [Test]
         public void TestFluintInterface_Include()
         {
             var cfg = TestHelper.CreateTestConfiguration();
@@ -155,6 +166,15 @@ namespace StatePrinter.Tests.FieldHarvesters
                 var harvester = new ProjectionHarvester();
                 harvester.Include<A>(x => x.X);
                 harvester.AddFilter<A>(x => null);
+            }
+
+            [Test]
+            [ExpectedException(typeof(ArgumentException), ExpectedMessage = "Type A has already been configured as a map.")]
+            public void AddFilter_OnAlreadyMap_Fail()
+            {
+                var cfg = TestHelper.CreateTestConfiguration();
+                cfg.Project.Map<A>(x => new { dims = "hejsa", ups = x.Name });
+                cfg.Project.AddFilter<A>(x => null);
             }
         }
 

--- a/StatePrinter/FieldHarvesters/HarvestHelper.cs
+++ b/StatePrinter/FieldHarvesters/HarvestHelper.cs
@@ -141,7 +141,8 @@ namespace StatePrinter.FieldHarvesters
 
         SanitizedFieldInfo GetSanitizedFieldInfoForFieldOrProperty(MemberInfo memberInfo)
         {
-            return GetSanitizedFieldInfoForFieldOrProperty(memberInfo, null, null);
+            var valueGetter = runTimeCodeGenerator.CreateGetter(memberInfo);
+            return new SanitizedFieldInfo(memberInfo, SanitizeFieldName(memberInfo.Name), valueGetter);
         }
 
         SanitizedFieldInfo GetSanitizedFieldInfoForFieldOrProperty(MemberInfo memberInfo, Expression mapexpression, Type basetype)

--- a/StatePrinter/FieldHarvesters/RunTimeCodeGenerator.cs
+++ b/StatePrinter/FieldHarvesters/RunTimeCodeGenerator.cs
@@ -24,10 +24,32 @@ using System.Reflection;
 namespace StatePrinter.FieldHarvesters
 {
     /// <summary>
-    /// Run-time code generation is much faster than using ordinary reflection such 
+    /// Run-time code generation is much faster than using ordinary reflection
     /// </summary>
     public class RunTimeCodeGenerator
     {
+        /// <summary>
+        /// A fast alternative to the reflection methods <see cref="FieldInfo.GetValue"/> and <see cref="PropertyInfo.GetValue(object,object[])"/>
+        /// </summary>
+        public Func<object, object> CreateGetter(MemberInfo memberInfo)
+        {
+            if (!(memberInfo is FieldInfo) && !(memberInfo is PropertyInfo))
+            {
+                throw new ArgumentException("Parameter memberInfo must be of type FieldInfo or PropertyInfo.");
+            }
+
+            if (memberInfo.DeclaringType == null)
+            {
+                throw new ArgumentException("MemberInfo cannot be a global member.");
+            }
+
+            var p = Expression.Parameter(typeof(object), "p");
+            var objExpr = Expression.Convert(p, memberInfo.DeclaringType);
+            var field = Expression.PropertyOrField(objExpr, memberInfo.Name);
+            var castRes = Expression.Convert(field, typeof(object));
+            return Expression.Lambda<Func<object, object>>(castRes, p).Compile();
+        }
+
         /// <summary>
         /// A fast alternative to the reflection methods <see cref="FieldInfo.GetValue"/> and <see cref="PropertyInfo.GetValue(object,object[])"/>
         /// </summary>
@@ -43,16 +65,21 @@ namespace StatePrinter.FieldHarvesters
                 throw new ArgumentException("MemberInfo cannot be a global member.");
             }
 
-            var p = Expression.Parameter(typeof(object), "p");
-            var objExpr = Expression.Convert(p, basetype ?? memberInfo.DeclaringType);
-            if (mapexpression != null)
+            if (mapexpression == null)
             {
-                var invokeMap = Expression.Invoke(mapexpression, objExpr);
-                objExpr = Expression.Convert(invokeMap, memberInfo.DeclaringType);
+                throw new ArgumentException("Mapexpression cannot be a null.");
             }
 
-            var field = Expression.PropertyOrField(objExpr, memberInfo.Name);
-            
+            if (basetype == null)
+            {
+                throw new ArgumentException("Basetype cannot be a null.");
+            }
+
+            var p = Expression.Parameter(typeof(object), "p");
+            var objExpr = Expression.Convert(p, basetype);
+            var invokeMap = Expression.Invoke(mapexpression, objExpr);
+            var typedMapExpr = Expression.Convert(invokeMap, memberInfo.DeclaringType);
+            var field = Expression.PropertyOrField(typedMapExpr, memberInfo.Name);
             var castRes = Expression.Convert(field, typeof(object));
             return Expression.Lambda<Func<object, object>>(castRes, p).Compile();
         }


### PR DESCRIPTION
Adds functionality to apply a map that takes a lambda function.
The lambdamust returns an anonymous object. The printer will then proceed to 
print the anonymous object, whenever the target type is printed.

Fixes #17 