### PR TITLE
Bugfix: Problem with rewriting expected values if value contains brackets.

### DIFF
--- a/StatePrinter.Tests/TestingAssistance/ParserTest.cs
+++ b/StatePrinter.Tests/TestingAssistance/ParserTest.cs
@@ -132,9 +132,13 @@ namespace StatePrinting.Tests.TestingAssistance
             TestHelper.Assert().PrintAreAlike(expected, r);
         }
 
-
-
-
+        [Test]
+        public void Expected_variable_contains_brackets()
+        {
+            var r = sut.ReplaceExpected("Assert.AreEqual(\"[0]\", sut.Do());", 1, "[0]", "boo");
+            TestHelper.Assert().PrintAreAlike(@"""Assert.AreEqual(boo, sut.Do());""", r);
+        }
+        
         [Test]
         public void Only_last_expected_changes_normal_string()
         {

--- a/StatePrinter/TestAssistance/Parser.cs
+++ b/StatePrinter/TestAssistance/Parser.cs
@@ -34,12 +34,12 @@ namespace StatePrinting.TestAssistance
             // The expected value to replace may either be represened as a string or a verbatim string. Thus we must look for both representations
             var reString = EscapeForString(originalExpected);
             var reVerbString = EscapeForVerbatimString(originalExpected);
-            Regex re= new Regex( "("
+            Regex re = new Regex("("
                 + reString
                 + "|"
                 + reVerbString
                 + ")", options);
-            
+
             var match = re.Match(content, index);
             if (!match.Success)
                 throw new ArgumentException("Did not find '" + originalExpected + "'");
@@ -66,7 +66,7 @@ namespace StatePrinting.TestAssistance
 
         string EscapeForVerbatimString(string s)
         {
-            return "@\"" 
+            return "@\""
                 + EscapeForRegEx(s).Replace("\"", "\"\"")
                 + "\"";
         }
@@ -79,7 +79,9 @@ namespace StatePrinting.TestAssistance
                 .Replace("(", "\\(")
                 .Replace(")", "\\)")
                 .Replace("|", "\\|")
-                .Replace("+", "\\+");
+                .Replace("+", "\\+")
+                .Replace("[", "\\[")
+                .Replace("]", "\\]");
         }
 
         /// <summary>
@@ -104,7 +106,7 @@ namespace StatePrinting.TestAssistance
             if (line == lineNo)
                 found = true;
 
-            if(found)
+            if (found)
                 return i;
 
             throw new ArgumentOutOfRangeException("content", "File does not have " + lineNo + " lines. Only " + line + " lines.");


### PR DESCRIPTION
Current version does not correctly rewrite expected  value, if given value contains brackets.
Example:

```var actual = new List<int>() { 1, 2, 3 };
string expected = @"new List<Int32>()
{
    [0] = 1
    [1] = 2
    [2] = 3
    [3] = 4
}";
TestHelper.Assert().PrintEquals(expected, actual);
```

This code should fix given problem.