### PR TITLE
Fix a race condition in HarvestInfoCache.TryAdd().

### DIFF
--- a/StatePrinter/Introspection/HarvestInfoCache.cs
+++ b/StatePrinter/Introspection/HarvestInfoCache.cs
@@ -54,7 +54,8 @@ namespace StatePrinting.Introspection
             cacheLock.EnterWriteLock();
             try
             {
-                if (!harvestCache.ContainsKey(type)) harvestCache.Add(type, fields);
+                if (!harvestCache.ContainsKey(type)) 
+                    harvestCache.Add(type, fields);
             }
             finally
             {

--- a/StatePrinter/Introspection/HarvestInfoCache.cs
+++ b/StatePrinter/Introspection/HarvestInfoCache.cs
@@ -54,7 +54,7 @@ namespace StatePrinting.Introspection
             cacheLock.EnterWriteLock();
             try
             {
-                harvestCache.Add(type, fields);
+                if (!harvestCache.ContainsKey(type)) harvestCache.Add(type, fields);
             }
             finally
             {


### PR DESCRIPTION
HarvestInfoCache.TryAdd() can be called concurrently, in which case it can throw ArgumentException when adding a type that has already been added by another thread.