### PR TITLE
Improved Enum output

### DIFF
--- a/StatePrinter/ValueConverters/EnumConverter.cs
+++ b/StatePrinter/ValueConverters/EnumConverter.cs
@@ -33,7 +33,7 @@ namespace StatePrinting.ValueConverters
 
         public string Convert(object source)
         {
-            return System.Enum.GetName(source.GetType(), source);
+            return source.ToString();
         }
     }
 }


### PR DESCRIPTION
I noticed, that `Enum.GetName(Type, object)` gives empty string for values that are not defined in the enum. Those can exist in C#. The ways to create them are the `Enum.Parse` method and explicit conversion from numeric type `(EnumType)42`. And because this can lead to errors and confusions, it's especially important that they print out.
Furthermore, empty string is even returned for combined values of enum, even though it has the [Flags] attribute (`EnumType.Flag1 | EnumType.Flag2`), if they're not named (`Flag1And2 = Flag1 | Flag2`).
Proposed method of using `ToString()` solves both these issues by printing numeric value for unnamed values (e.g. `"42"`) and even recognizing when the enum is defined with `Flags` and the value consist of combination of them and providing list (e.g. `"Flag1, Flag2"`).