### PR TITLE
Custom Ordering

### DIFF
--- a/StatePrinter.Tests/Configurations/ConfigurationTest.cs
+++ b/StatePrinter.Tests/Configurations/ConfigurationTest.cs
@@ -60,7 +60,7 @@ namespace StatePrinting.Tests.Configurations
             var orderer = new ComparableOrderer();
             config.Add(orderer);
 
-            Assert.IsTrue(config.TryGetEnumerableOrderer(typeof(decimal), out var h));
+            Assert.IsTrue(config.TryGetEnumerableOrderer(typeof(IEnumerable<decimal>), out var h));
             Assert.AreEqual(h, orderer);
         }
 

--- a/StatePrinter.Tests/Configurations/ConfigurationTest.cs
+++ b/StatePrinter.Tests/Configurations/ConfigurationTest.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using StatePrinting.Orderers;
 using StatePrinting.Configurations;
 using StatePrinting.FieldHarvesters;
 using StatePrinting.TestAssistance;
@@ -32,7 +33,7 @@ namespace StatePrinting.Tests.Configurations
     class ConfigurationTest
     {
         [Test]
-        public void TryFind()
+        public void TryGetValueConverter()
         {
             var config = new Configuration();
             config.Add(new StandardTypesConverter(null));
@@ -40,6 +41,27 @@ namespace StatePrinting.Tests.Configurations
             IValueConverter h;
             Assert.IsTrue(config.TryGetValueConverter(typeof(decimal), out h));
             Assert.IsTrue(h is StandardTypesConverter);
+        }
+
+        [Test]
+        public void TryGetFieldHarvester()
+        {
+            var config = new Configuration();
+            config.AddHandler(type => type == typeof(decimal), type => new List<SanitizedFieldInfo>());
+
+            Assert.IsTrue(config.TryGetFieldHarvester(typeof(decimal), out var h));
+            Assert.IsTrue(h is AnonymousHarvester);
+        }
+
+        [Test]
+        public void TryGetEnumerableOrderer()
+        {
+            var config = new Configuration();
+            var orderer = new ComparableOrderer();
+            config.Add(orderer);
+
+            Assert.IsTrue(config.TryGetEnumerableOrderer(typeof(decimal), out var h));
+            Assert.AreEqual(h, orderer);
         }
 
         [Test]
@@ -53,10 +75,15 @@ namespace StatePrinting.Tests.Configurations
 
             Assert.Throws<ArgumentNullException>(() => sut.Add((IFieldHarvester)null));
             Assert.Throws<ArgumentNullException>(() => sut.Add((IValueConverter)null));
+            Assert.Throws<ArgumentNullException>(() => sut.Add((IEnumerableOrderer)null));
 
             Assert.Throws<ArgumentNullException>(() => sut.AddHandler(null, t => new List<SanitizedFieldInfo>()));
             Assert.Throws<ArgumentNullException>(() => sut.AddHandler(t => true, null));
             Assert.Throws<ArgumentNullException>(() => sut.AddHandler(null, null));
+
+            Assert.Throws<ArgumentNullException>(() => sut.AddOrderer(null, x => x));
+            Assert.Throws<ArgumentNullException>(() => sut.AddOrderer(x => true, null));
+            Assert.Throws<ArgumentNullException>(() => sut.AddOrderer(null, null));
 
             Assert.Throws<ArgumentNullException>(() => sut.Test.SetAreEqualsMethod((TestFrameworkAreEqualsMethod) null));
             Assert.Throws<ArgumentNullException>(() => sut.Test.SetAutomaticTestRewrite(null));

--- a/StatePrinter.Tests/Orderers/AnonymousOrdererTest.cs
+++ b/StatePrinter.Tests/Orderers/AnonymousOrdererTest.cs
@@ -1,0 +1,67 @@
+﻿//// Copyright 2014 Kasper B. Graversen
+//// 
+//// Licensed to the Apache Software Foundation (ASF) under one
+//// or more contributor license agreements.  See the NOTICE file
+//// distributed with this work for additional information
+//// regarding copyright ownership.  The ASF licenses this file
+//// to you under the Apache License, Version 2.0 (the
+//// "License"); you may not use this file except in compliance
+//// with the License.  You may obtain a copy of the License at
+//// 
+////   http://www.apache.org/licenses/LICENSE-2.0
+//// 
+//// Unless required by applicable law or agreed to in writing,
+//// software distributed under the License is distributed on an
+//// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//// KIND, either express or implied.  See the License for the
+//// specific language governing permissions and limitations
+//// under the License.
+
+using NUnit.Framework;
+using StatePrinting.Configurations;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StatePrinting.Tests.Orderers
+{
+    [TestFixture]
+    class AnonymousOrdererTest
+    {
+        [Test]
+        public void AnonymousOrdererUsesOrderFuncForHandledType()
+        {
+            var cfg = ConfigurationHelper.GetStandardConfiguration(" ");
+            cfg.AddOrderer(type => type == typeof(List<int>), enumerable => enumerable.Cast<int>().Reverse());
+            var statePrinter = new Stateprinter(cfg);
+            var list = new List<int>() { 0, 1, 2 };
+
+            var actual = statePrinter.PrintObject(list);
+
+            var expected = @"new List<Int32>()
+{
+ [0] = 2
+ [1] = 1
+ [2] = 0
+}";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void AnonymousOrdererDoesNotUseOrderFuncForUnhandledType()
+        {
+            var cfg = ConfigurationHelper.GetStandardConfiguration(" ");
+            cfg.AddOrderer(type => false, enumerable => null);
+            var statePrinter = new Stateprinter(cfg);
+            var list = new List<int> { 1, 0 };
+
+            var actual = statePrinter.PrintObject(list);
+
+            var expected = @"new List<Int32>()
+{
+ [0] = 1
+ [1] = 0
+}";
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/StatePrinter.Tests/Orderers/ComparableOrdererTest.cs
+++ b/StatePrinter.Tests/Orderers/ComparableOrdererTest.cs
@@ -1,0 +1,145 @@
+﻿// Copyright 2014 Kasper B. Graversen
+// 
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using NUnit.Framework;
+using StatePrinting.Configurations;
+using StatePrinting.Orderers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StatePrinting.Tests.Orderers
+{
+    [TestFixture]
+    class ComparableOrdererTest
+    {
+        [TestFixture]
+        class UnitTests
+        {
+            [TestCase(typeof(IEnumerable<IComparable>), ExpectedResult = true)]
+            [TestCase(typeof(int), ExpectedResult = false)]
+            [TestCase(typeof(List<int>), ExpectedResult = true)]
+            [TestCase(typeof(IEnumerable<int>), ExpectedResult = true)]
+            [TestCase(typeof(Dictionary<int, int>), ExpectedResult = false)]
+            [TestCase(typeof(Dictionary<int, ComparableOrdererTest>), ExpectedResult = false)]
+            [TestCase(typeof(Dictionary<ComparableOrdererTest, ComparableOrdererTest>), ExpectedResult = false)]
+            [TestCase(typeof(Dictionary<int, int>.KeyCollection), ExpectedResult = true)]
+            [TestCase(typeof(NonGenericTypeImplementingIEnumerable), ExpectedResult = true)]
+            public bool CanHandleTypesImplementingIEnumerableOfIComparables(Type type)
+            {
+                var comparableOrderer = new ComparableOrderer();
+
+                return comparableOrderer.CanHandleType(type);
+            }
+
+            [Test]
+            public void CanOrderArrayOfValueTypes()
+            {
+                var comparableOrderer = new ComparableOrderer();
+                var ints = new object[] { 5, 1, 3, 4, 2 };
+
+                var ordered = comparableOrderer.Order(ints).Cast<int>().ToArray();
+
+                var expected = new[] { 1, 2, 3, 4, 5 };
+                CollectionAssert.AreEqual(expected, ordered);
+            }
+
+            [Test]
+            public void CanOrderArrayOfReferenceTypes()
+            {
+                var comparableOrderer = new ComparableOrderer();
+                var strings = new[] { "c", "a", "b" };
+
+                var ordered = comparableOrderer.Order(strings).Cast<string>().ToArray();
+
+                var expected = new[] { "a", "b", "c" };
+                CollectionAssert.AreEqual(expected, ordered);
+            }
+
+            [Test]
+            public void CannotOrderArrayOfDifferentTypes()
+            {
+                var comparableOrderer = new ComparableOrderer();
+                var array = new object[] { 1, "a" };
+
+                Assert.Throws<ArgumentException>(() => comparableOrderer.Order(array).Cast<object>().ToArray());
+            }
+
+            class NonGenericTypeImplementingIEnumerable : IEnumerable<int>
+            {
+                public IEnumerator<int> GetEnumerator() => throw new NotImplementedException();
+
+                IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+            }
+        }
+
+        [TestFixture]
+        public class IntegrationTests
+        {
+            [Test]
+            public void IsUsedForEnumerables()
+            {
+                Stateprinter statePrinter = GetStatePrinterWithComparableOrderer();
+                var list = new List<int>() { 3, 1, 2, 0 };
+
+                var actual = statePrinter.PrintObject(list);
+
+                var expected = @"new List<Int32>()
+{
+ [0] = 0
+ [1] = 1
+ [2] = 2
+ [3] = 3
+}";
+                Assert.AreEqual(expected, actual);
+            }
+
+            [Test]
+            public void IsUsedForDictionaries()
+            {
+                var statePrinter = GetStatePrinterWithComparableOrderer();
+                var dictionary = new Dictionary<int, int>()
+                {
+                    { 3, 1 },
+                    { 1, 2 },
+                    { 2, 3 },
+                };
+
+                var actual = statePrinter.PrintObject(dictionary);
+
+                var expected = @"new Dictionary<Int32, Int32>()
+{
+ [1] = 2
+ [2] = 3
+ [3] = 1
+}";
+                Assert.AreEqual(expected, actual);
+            }
+
+            private static Stateprinter GetStatePrinterWithComparableOrderer()
+            {
+                var cfg = ConfigurationHelper.GetStandardConfiguration(" ");
+                cfg.Add(new ComparableOrderer());
+                var statePrinter = new Stateprinter(cfg);
+                return statePrinter;
+            }
+        }
+    }
+}

--- a/StatePrinter.Tests/StatePrinter.Tests.csproj
+++ b/StatePrinter.Tests/StatePrinter.Tests.csproj
@@ -68,6 +68,8 @@
     <Compile Include="FieldHarvesters\ToStringAwareHarvesterTest.cs" />
     <Compile Include="Introspection\ReferenceTest.cs" />
     <Compile Include="Mocks\Mocks.cs" />
+    <Compile Include="Orderers\AnonymousOrdererTest.cs" />
+    <Compile Include="Orderers\ComparableOrdererTest.cs" />
     <Compile Include="OutputFormatters\RollingGuidValueConverterTest.cs" />
     <Compile Include="PerformanceTests\ManySmallCollections.cs" />
     <Compile Include="PerformanceTests\PerformanceTestsBase.cs" />

--- a/StatePrinter/FieldHarvesters/IFieldHarvester.cs
+++ b/StatePrinter/FieldHarvesters/IFieldHarvester.cs
@@ -25,10 +25,8 @@ namespace StatePrinting.FieldHarvesters
     /// <summary>
     /// A fieldharvester is a configuration part that given a type is able to harvest all fields on it.
     /// </summary>
-    public interface IFieldHarvester
+    public interface IFieldHarvester : IHandler
     {
-        bool CanHandleType(Type type);
-
         List<SanitizedFieldInfo> GetFields(Type type);
     }
 }

--- a/StatePrinter/FieldHarvesters/ProjectionHarvester.cs
+++ b/StatePrinter/FieldHarvesters/ProjectionHarvester.cs
@@ -95,7 +95,7 @@ namespace StatePrinting.FieldHarvesters
             return false;
         }
 
-        bool IFieldHarvester.CanHandleType(Type type)
+        bool IHandler.CanHandleType(Type type)
         {
             if (SelectStrategy(type, excluders, Strategy.Excluder)) return true;
             if (SelectStrategy(type, includers, Strategy.Includer)) return true;

--- a/StatePrinter/IHandler.cs
+++ b/StatePrinter/IHandler.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Kasper B. Graversen
+﻿// Copyright 2014 Kasper B. Graversen
 // 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -19,16 +19,13 @@
 
 using System;
 
-namespace StatePrinting.ValueConverters
+namespace StatePrinting
 {
-    /// <summary>
-    /// A handler that is able to convert a value of specific types to on a single line string.
-    /// </summary>
-    public interface IValueConverter : IHandler
+    public interface IHandler
     {
         /// <summary>
-        /// Convert objects of handled types into a simple one-line representation.
+        /// Is the type covered by this handler.
         /// </summary>
-        string Convert(object source);
+        bool CanHandleType(Type type);
     }
 }

--- a/StatePrinter/Orderers/AnonymousOrderer.cs
+++ b/StatePrinter/Orderers/AnonymousOrderer.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Kasper B. Graversen
+﻿// Copyright 2014 Kasper B. Graversen
 // 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -18,17 +18,32 @@
 // under the License.
 
 using System;
+using System.Collections;
 
-namespace StatePrinting.ValueConverters
+namespace StatePrinting.Orderers
 {
     /// <summary>
-    /// A handler that is able to convert a value of specific types to on a single line string.
+    /// Applies an ordering to the specified types using the specified function.
     /// </summary>
-    public interface IValueConverter : IHandler
+    class AnonymousOrderer : IEnumerableOrderer
     {
-        /// <summary>
-        /// Convert objects of handled types into a simple one-line representation.
-        /// </summary>
-        string Convert(object source);
+        private readonly Func<Type, bool> canHandleTypeFunc;
+        private readonly Func<IEnumerable, IEnumerable> orderFunc;
+
+        public AnonymousOrderer(Func<Type, bool> canHandleTypeFunc, Func<IEnumerable, IEnumerable> orderFunc)
+        {
+            this.canHandleTypeFunc = canHandleTypeFunc;
+            this.orderFunc = orderFunc;
+        }
+
+        public bool CanHandleType(Type type)
+        {
+            return canHandleTypeFunc(type);
+        }
+
+        public IEnumerable Order(IEnumerable source)
+        {
+            return orderFunc(source);
+        }
     }
 }

--- a/StatePrinter/Orderers/ComparableOrderer.cs
+++ b/StatePrinter/Orderers/ComparableOrderer.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Kasper B. Graversen
+﻿// Copyright 2014 Kasper B. Graversen
 // 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -18,17 +18,31 @@
 // under the License.
 
 using System;
+using System.Collections;
+using System.Linq;
 
-namespace StatePrinting.ValueConverters
+namespace StatePrinting.Orderers
 {
     /// <summary>
-    /// A handler that is able to convert a value of specific types to on a single line string.
+    /// Orders any <see cref="System.Collections.Generic.IEnumerable{T}"/> containing elements
+    /// implementing <see cref="IComparable"/> into ascending order.
     /// </summary>
-    public interface IValueConverter : IHandler
+    public class ComparableOrderer : IEnumerableOrderer
     {
-        /// <summary>
-        /// Convert objects of handled types into a simple one-line representation.
-        /// </summary>
-        string Convert(object source);
+        public bool CanHandleType(Type type)
+        {
+            return OrdererHelpers.ImplementsIEnumerableOf<IComparable>(type);
+        }
+
+        public IEnumerable Order(IEnumerable source)
+        {
+            var comparableElements = source.OfType<IComparable>();
+            if (comparableElements.Any())
+            {
+                return comparableElements.OrderBy(x => x);
+            }
+
+            return source;
+        }
     }
 }

--- a/StatePrinter/Orderers/IEnumerableOrderer.cs
+++ b/StatePrinter/Orderers/IEnumerableOrderer.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Kasper B. Graversen
+﻿// Copyright 2014 Kasper B. Graversen
 // 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -17,18 +17,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
+using System.Collections;
 
-namespace StatePrinting.ValueConverters
+namespace StatePrinting.Orderers
 {
     /// <summary>
-    /// A handler that is able to convert a value of specific types to on a single line string.
+    /// A handler that can apply an ordering to a specific IEnumerable
     /// </summary>
-    public interface IValueConverter : IHandler
+    public interface IEnumerableOrderer : IHandler
     {
-        /// <summary>
-        /// Convert objects of handled types into a simple one-line representation.
-        /// </summary>
-        string Convert(object source);
+        IEnumerable Order(IEnumerable source);
     }
 }

--- a/StatePrinter/Orderers/OrdererHelpers.cs
+++ b/StatePrinter/Orderers/OrdererHelpers.cs
@@ -1,0 +1,43 @@
+﻿//// Copyright 2014 Kasper B. Graversen
+//// 
+//// Licensed to the Apache Software Foundation (ASF) under one
+//// or more contributor license agreements.  See the NOTICE file
+//// distributed with this work for additional information
+//// regarding copyright ownership.  The ASF licenses this file
+//// to you under the Apache License, Version 2.0 (the
+//// "License"); you may not use this file except in compliance
+//// with the License.  You may obtain a copy of the License at
+//// 
+////   http://www.apache.org/licenses/LICENSE-2.0
+//// 
+//// Unless required by applicable law or agreed to in writing,
+//// software distributed under the License is distributed on an
+//// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//// KIND, either express or implied.  See the License for the
+//// specific language governing permissions and limitations
+//// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StatePrinting.Orderers
+{
+    public static class OrdererHelpers
+    {
+        /// <summary>
+        /// Returns whether the given <see cref="Type"/> implements a generic
+        /// <see cref="IEnumerable{T}"/> whose elements are assignable to TElement
+        /// </summary>
+        public static bool ImplementsIEnumerableOf<TElement>(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return typeof(TElement).IsAssignableFrom(type.GetGenericArguments()[0]);
+            }
+
+            var enumerables = type.GetInterfaces().Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+            return enumerables.Any(e => typeof(TElement).IsAssignableFrom(e.GetGenericArguments()[0]));
+        }
+    }
+}

--- a/StatePrinter/StatePrinter.csproj
+++ b/StatePrinter/StatePrinter.csproj
@@ -58,6 +58,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Orderers\AnonymousOrderer.cs" />
+    <Compile Include="Orderers\ComparableOrderer.cs" />
+    <Compile Include="Orderers\IEnumerableOrderer.cs" />
+    <Compile Include="Orderers\OrdererHelpers.cs" />
     <Compile Include="Configurations\Configuration.cs" />
     <Compile Include="Configurations\ConfigurationHelper.cs" />
     <Compile Include="Configurations\LegacyBehaviour.cs" />
@@ -74,6 +78,7 @@
     <Compile Include="FieldHarvesters\HarvestHelper.cs" />
     <Compile Include="FieldHarvesters\IFieldHarvester.cs" />
     <Compile Include="FieldHarvesters\PublicFieldsAndPropertiesHarvester .cs" />
+    <Compile Include="IHandler.cs" />
     <Compile Include="Introspection\HarvestInfoCache.cs" />
     <Compile Include="Introspection\IntroSpector.cs" />
     <Compile Include="Introspection\Reference.cs" />


### PR DESCRIPTION
This PR implements #18. We are using StatePrinter with [ApprovalTests](https://github.com/approvals/ApprovalTests.Net) for characterization tests that we run on our data model. Ordering of items sometimes changes in this model, but we don't want the tests to fail due to that most of the time. Custom orderers let us avoid that.
- Added `ComparableOrderer` that orders all collections of IComparable objects into ascending order
- Added `AnonymousOrderer` that orders based on given Funcs
- The orderers can be added to the `Configuration` like the field harvesters and value converters
- Orderers are used in `Introspector` for Dictionaries (ordering Keys) and IEnumerables
- Minor refactor introducing `IHandler` to reduce duplication in `Configuration`

Thanks for the awesome library @kbilsted!